### PR TITLE
Add monthly cron build

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches: [ "latest" ]
 
+  # Run builds on the first of every month to keep images up to date
+  schedule:
+    - cron: "0 0 1 * *"
+
 env:
   REGISTRY: ghcr.io
 
@@ -15,7 +19,7 @@ jobs:
       matrix:
         python-tag: [ "python36", "python38", "python39" ]
         rocky-tag: [ "8" ]
-        slurm-tag: [ "slurm-20-02-5-1", "slurm-20-11-9-1", "slurm-22-05-2-1" ]
+        slurm-tag: [ "slurm-20-02-5-1", "slurm-22-05-2-1", "slurm-20-11-9-1" ]
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
This will help ensure built images stay up to date and will help things fail fast. Some example situations include:

- If an upstream source is modified and no longer accessible
- If a package with an unpinned version changes in a way that breaks backward compatibility

In situations like the above, we want our test suites to fail as early as possible.