### PR TITLE
Change shell option to exit immediately if a pipeline returns a non-zero

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -eo pipefail
 
 echo "Launching sql server..."
 /usr/bin/mysqld_safe --datadir='/var/lib/mysql' &


### PR DESCRIPTION
This will close #7.

Adjust the shell options to exit immediately if any of the commands returns a non-zero status. Returns the value of the last command to exit with a non-zero status, or 0 if all commands exit successfully. This should catch any errors in the `entrypoint.sh` script and stop the Actions pipeline with a failed step.

Reference: https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html