### PR TITLE
Add dummy job for branch protections

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -82,6 +82,18 @@ jobs:
           path: image.tar
           if-no-files-found: error
 
+  # This is a dummy job used to facilitate branch protections
+  # and trigger auto-merging when all jobs in the build matrix
+  # exit succesfully.
+  build-successful:
+    needs: [ setup-matrix, build ]
+    runs-on: ubuntu-latest
+    name: Builds were succesful
+    
+    steps:
+      - name: Mark as completed
+        run: echo "The builds were successful"
+  
   publish:
     if: github.ref == 'refs/heads/latest' && github.event_name == 'push'  # Only publish from the latest branch
     needs: [ setup-matrix, build ]


### PR DESCRIPTION
Adds the `build-successful` job to the CI. 

The new job doesn't do anything except echo `"The builds were successful"`. The job will always execute successfully so long as the required upstream jobs (i.e., the docker test builds) also execute succesfully. This makes life easier in two ways:

1. Branch protection rules can be configured to pass once the dummy job executes instead of manually adding separate protection rules for every single matrix entry in the `build` job. This is easier to set up and eliminates manual management of the branch protection rules as new build configurations are added.
2. The aforementioned protection rule can be used to facilitate auto-merging.