### PR TITLE
Add mock slurm accounts to entrypoint script

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,27 @@ To see a list of valid Slurm tags, see the [Slurm GitHub release tags](https://g
 
 To see a list of valid Rocky tags, see the [Rocky DockerHub images](https://hub.docker.com/_/rockylinux).
 
-To see a list of valid Python tags, check the yum package repository
+To see a list of valid Python tags, check the yum package repository.
+
+## Testing Fixtures
+
+The test environment comes partially configured with running services and mock data. 
+
+### Running services
+
+The following services are automatically launched when spinning up a new container:
+- `munge`
+- `slurmdbd`
+- `slurmctld`
+
+### Slurm Configuration
+
+Slurm is configured with a single mock cluster called ``??``. The following Slurm accounts on the cluster:
+
+| Account Name | Slurm Description | Slurm Organization |
+|--------------|-------------------|--------------------|
+| account1     | account1_desc     | account1_org       |
+| account2     | account2_desc     | account2_org       |
 
 ## Creating a New Image
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -32,4 +32,8 @@ echo "Starting slurmdbd..."
 echo "Starting slurmctld..."
 /usr/sbin/slurmctld
 
+echo "Creating mock user accounts..."
+sacctmgr -i add account "account1" description="account1_desc" organization="account1_org"
+sacctmgr -i add account "account2" description="account2_desc" organization="account2_org"
+
 exec "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -32,7 +32,7 @@ echo "Starting slurmctld..."
 mkdir /var/slurmstate
 chown slurm /var/slurmstate
 /usr/sbin/slurmctld -c
-sleep 10 # Wait for slurmctld to start up
+sleep 3 # Wait for slurmctld to start up
 
 echo "Creating mock user accounts..."
 sacctmgr -i add account "account1" description="account1_desc" organization="account1_org"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -32,7 +32,7 @@ echo "Starting slurmctld..."
 mkdir /var/slurmstate
 chown slurm /var/slurmstate
 /usr/sbin/slurmctld -c
-sleep 3 # Wait for slurmctld to start up
+sleep 10 # Wait for slurmctld to start up
 
 echo "Creating mock user accounts..."
 sacctmgr -i add account "account1" description="account1_desc" organization="account1_org"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,14 +3,7 @@ set -eo pipefail
 
 echo "Launching sql server..."
 /usr/bin/mysqld_safe --datadir='/var/lib/mysql' &
-
-# Wait for mysql to start up
-for i in {30..0}; do
-  if echo "SELECT 1" | mysql &>/dev/null; then
-    break
-  fi
-  sleep 1
-done
+sleep 3 # Wait for mysql to start up
 
 echo "Creating Slurm account database..."
 mysql -NBe "CREATE DATABASE slurm_acct_db"
@@ -27,6 +20,7 @@ echo "Starting munge..."
 
 echo "Starting slurmdbd..."
 /usr/sbin/slurmdbd
+sleep 3 # Wait for slurmdbd to start up
 
 echo "Starting slurmctld..."
 mkdir /var/slurmstate

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,7 +31,8 @@ echo "Starting slurmdbd..."
 echo "Starting slurmctld..."
 mkdir /var/slurmstate
 chown slurm /var/slurmstate
-/usr/sbin/slurmctld -D
+/usr/sbin/slurmctld -c
+sleep 3 # Wait for slurmctld to start up
 
 echo "Creating mock user accounts..."
 sacctmgr -i add account "account1" description="account1_desc" organization="account1_org"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,7 +15,6 @@ done
 echo "Creating Slurm account database..."
 mysql -NBe "CREATE DATABASE slurm_acct_db"
 mysql -NBe "CREATE USER 'slurm'@'localhost'"
-mysql -NBe "SET PASSWORD for 'slurm'@'localhost' = password('password')"
 mysql -NBe "GRANT USAGE ON *.* to 'slurm'@'localhost'"
 mysql -NBe "GRANT ALL PRIVILEGES on slurm_acct_db.* to 'slurm'@'localhost'"
 mysql -NBe "FLUSH PRIVILEGES"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,7 +29,9 @@ echo "Starting slurmdbd..."
 /usr/sbin/slurmdbd
 
 echo "Starting slurmctld..."
-/usr/sbin/slurmctld
+mkdir /var/slurmstate
+chown slurm /var/slurmstate
+/usr/sbin/slurmctld -D
 
 echo "Creating mock user accounts..."
 sacctmgr -i add account "account1" description="account1_desc" organization="account1_org"

--- a/slurm_config/slurm-20-02-5-1/slurm.conf
+++ b/slurm_config/slurm-20-02-5-1/slurm.conf
@@ -24,7 +24,7 @@ CryptoType=crypto/munge
 #JobCredentialPublicCertificate=
 #JobFileAppend=0
 #JobRequeue=1
-JobSubmitPlugins="lua"
+#JobSubmitPlugins="lua"
 #KillOnBadExit=0
 #LaunchType=launch/slurm
 Licenses=stata:17
@@ -175,7 +175,7 @@ GresTypes=gpu,mic,nvme
 AccountingStorageTRES=gres/gpu,license/stata,gres/scratch
 
 # COMPUTE NODES
-NodeName=c[1-10] NodeHostName=localhost NodeAddr=127.0.0.1 RealMemory=1000
+NodeName=c[1-10] RealMemory=1000
 #
 # PARTITIONS
 PartitionName=normal Default=yes Nodes=c[1-5] Priority=50 DefMemPerCPU=500 Shared=NO MaxNodes=1 MaxTime=5-00:00:00 DefaultTime=5-00:00:00 State=UP

--- a/slurm_config/slurm-20-11-9-1/slurm.conf
+++ b/slurm_config/slurm-20-11-9-1/slurm.conf
@@ -24,7 +24,7 @@ CryptoType=crypto/munge
 #JobCredentialPublicCertificate=
 #JobFileAppend=0
 #JobRequeue=1
-JobSubmitPlugins="lua"
+#JobSubmitPlugins="lua"
 #KillOnBadExit=0
 #LaunchType=launch/slurm
 Licenses=stata:17
@@ -175,7 +175,7 @@ GresTypes=gpu,mic,nvme
 AccountingStorageTRES=gres/gpu,license/stata,gres/scratch
 
 # COMPUTE NODES
-NodeName=c[1-10] NodeHostName=localhost NodeAddr=127.0.0.1 RealMemory=1000
+NodeName=c RealMemory=1000
 #
 # PARTITIONS
 PartitionName=normal Default=yes Nodes=c[1-5] Priority=50 DefMemPerCPU=500 Shared=NO MaxNodes=1 MaxTime=5-00:00:00 DefaultTime=5-00:00:00 State=UP

--- a/slurm_config/slurm-22-05-2-1/slurm.conf
+++ b/slurm_config/slurm-22-05-2-1/slurm.conf
@@ -24,7 +24,7 @@ CryptoType=crypto/munge
 #JobCredentialPublicCertificate=
 #JobFileAppend=0
 #JobRequeue=1
-JobSubmitPlugins="lua"
+#JobSubmitPlugins="lua"
 #KillOnBadExit=0
 #LaunchType=launch/slurm
 Licenses=stata:17
@@ -175,7 +175,7 @@ GresTypes=gpu,mic,nvme
 AccountingStorageTRES=gres/gpu,license/stata,gres/scratch
 
 # COMPUTE NODES
-NodeName=c[1-10] NodeHostName=localhost NodeAddr=127.0.0.1 RealMemory=1000
+NodeName=c[1-10] RealMemory=1000
 #
 # PARTITIONS
 PartitionName=normal Default=yes Nodes=c[1-5] Priority=50 DefMemPerCPU=500 Shared=NO MaxNodes=1 MaxTime=5-00:00:00 DefaultTime=5-00:00:00 State=UP


### PR DESCRIPTION
A full description of what user data should be added to the image is still up in the air. However, adding some mock Slurm accounts will get us most of the way towards usability downstream.

I've added the necessary `sacctmgr` commands ~but it looks like a cluster hasn't been configured with Slurm.~

~@iamtroy412 do you know if new clusters are added via the config files or via the command line?~

Apologies, I was looking at the wrong build log. The actual error is 

```
Creating mock user accounts...
2022-08-31T03:19:54.968323866Z sacctmgr: error: slurm_persist_conn_open_without_init: failed to open persistent connection to localhost:6819: Connection refused
2022-08-31T03:19:54.968337497Z sacctmgr: error: slurmdbd: Sending PersistInit msg: Connection refused
2022-08-31T03:19:54.968341475Z sacctmgr: error: Problem talking to the database: Connection refused
```

Perhaps this is related to #31 ?

Tagging related issue #24 