### PR TITLE
Only create new version on release published

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,6 +7,7 @@ on:
 
   # These triggers will build, test, and publish the image(s)
   release:
+    types: [ published ]
   push:
     branches: [ "latest" ]
 


### PR DESCRIPTION
Fixes a bug where releases trigger three separate builds