### PR TITLE
Delete old published images

### DIFF
--- a/.github/workflows/docker-cleanup.yml
+++ b/.github/workflows/docker-cleanup.yml
@@ -1,0 +1,24 @@
+name: Delete Old Docker Images
+
+on:
+  workflow_dispatch:
+  workflow_call:
+  schedule:
+    - cron: '0 0 * * *'  # every day at midnight
+
+jobs:
+  delete-old:
+    needs: [ define-build-options, publish ]
+    runs-on: ubuntu-latest
+    name: Delete Old Images
+
+    steps:
+      - name: Delete old packages
+        uses: SmartsquareGmbH/delete-old-packages@v0.5.0
+        with:
+          token: ${{ secrets.GH_ACCESS_TOKEN }}
+          organization: my-organization
+          type: container
+          version-pattern: "^[^vV].*"
+          keep: 3
+          dry-run: true

--- a/.github/workflows/docker-cleanup.yml
+++ b/.github/workflows/docker-cleanup.yml
@@ -13,6 +13,8 @@ jobs:
     name: Delete Old Images
 
     steps:
+      # Clean up all versions that do not start with a 'v'
+      # This should be equivalent to all versions except releases
       - name: Delete old packages
         uses: SmartsquareGmbH/delete-old-packages@v0.5.0
         with:

--- a/.github/workflows/docker-cleanup.yml
+++ b/.github/workflows/docker-cleanup.yml
@@ -8,7 +8,6 @@ on:
 
 jobs:
   delete-old:
-    needs: [ define-build-options, publish ]
     runs-on: ubuntu-latest
     name: Delete Old Images
 

--- a/.github/workflows/docker-cleanup.yml
+++ b/.github/workflows/docker-cleanup.yml
@@ -17,8 +17,9 @@ jobs:
       - name: Delete old packages
         uses: SmartsquareGmbH/delete-old-packages@v0.5.0
         with:
-          token: ${{ secrets.GH_ACCESS_TOKEN }}
-          organization: my-organization
+          token: ${{ github.token }}
+          organization:  pitt-crc
+          repo: ${{ secrets.repository }}
           type: container
           version-pattern: "^[^vV].*"
           keep: 3

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -146,4 +146,4 @@ jobs:
     if: github.event_name != 'release'
     needs: [ define-build-options, publish ]
     name: Delete Old Images
-    uses: .github/workflows/docker-cleanup.yml
+    uses: .github/workflows/docker-cleanup.yml@${{ github.ref }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -141,33 +141,9 @@ jobs:
         run: |
           docker load --input image.tar
           docker push ghcr.io/${{ github.repository_owner }}/${{ steps.image-name.outputs.name }}:${{ github.ref_name }}
-          
+
   delete-old:
     if: github.event_name != 'release'
     needs: [ define-build-options, publish ]
-    runs-on: ubuntu-latest
     name: Delete Old Images
-  
-    steps: 
-      - name: Delete old packages
-        uses: SmartsquareGmbH/delete-old-packages@v0.5.0
-        with:
-          token: ${{ secrets.GH_ACCESS_TOKEN }}
-          organization: my-organization
-          type: container
-          version-pattern: "^[^vV].*"
-          keep: 3
-          dry-run: true
-      
-      
-      
-      
-      
-      
-      
-      
-      
-      
-      
-      
-      
+    uses: .github/workflows/docker-cleanup.yml

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -141,3 +141,33 @@ jobs:
         run: |
           docker load --input image.tar
           docker push ghcr.io/${{ github.repository_owner }}/${{ steps.image-name.outputs.name }}:${{ github.ref_name }}
+          
+  delete-old:
+    if: github.event_name != 'release'
+    needs: [ define-build-options, publish ]
+    runs-on: ubuntu-latest
+    name: Delete Old Images
+  
+    steps: 
+      - name: Delete old packages
+        uses: SmartsquareGmbH/delete-old-packages@v0.5.0
+        with:
+          token: ${{ secrets.GH_ACCESS_TOKEN }}
+          organization: my-organization
+          type: container
+          version-pattern: "^[^vV].*"
+          keep: 3
+          dry-run: true
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -146,4 +146,4 @@ jobs:
     if: github.event_name != 'release'
     needs: [ define-build-options, publish ]
     name: Delete Old Images
-    uses: .github/workflows/docker-cleanup.yml@${{ github.ref }}
+    uses: ./.github/workflows/docker-cleanup.yml


### PR DESCRIPTION
I've added a reusable workflow for deleting old package versions. The workflow runs every day at midnight in addition to every time new packages are published.

Versions published as part of a release (i.e., versions starting with a `v`) are not deleted.