### PR TITLE
Add version checks for all slurm utilities

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -54,9 +54,9 @@ jobs:
       # Check slurm utilities execute
       - name: Test slurm install
         run: |
-          docker run --rm ${{ steps.image-name.outputs.name }} sacctmgr -V
-          docker run --rm ${{ steps.image-name.outputs.name }} slurmctld -V
-          docker run --rm ${{ steps.image-name.outputs.name }} slurmdbd -V
+          docker run --rm ${{ steps.meta.outputs.tags }} sacctmgr -V
+          docker run --rm ${{ steps.meta.outputs.tags }} slurmctld -V
+          docker run --rm ${{ steps.meta.outputs.tags }} slurmdbd -V
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -51,9 +51,12 @@ jobs:
           build-args: |
             SLURM_TAG=${{ matrix.slurm-tag }}
 
-      # Make sure sacctmgr executes
+      # Check slurm utilities execute
       - name: Test slurm install
-        run: docker run --rm ${{ steps.meta.outputs.tags }} sacctmgr --version
+        run: |
+          docker run --rm ${{ steps.image-name.outputs.name }} sacctmgr -V
+          docker run --rm ${{ steps.image-name.outputs.name }} slurmctld -V
+          docker run --rm ${{ steps.image-name.outputs.name }} slurmdbd -V
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2


### PR DESCRIPTION
Adds checks for running `slurmdbd` and `slurmctl` instances by calling the version `-V` flag.

@iamtroy412 Does this resolve your issue #21 ? Or did you want more testing?