### PR TITLE
Fix failing CI for package releases

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -63,8 +63,8 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish built image
+        if: github.event_name == 'release'
         uses: docker/build-push-action@v3
-        if: (github.ref == 'refs/heads/latest' && github.event_name == 'push') || (github.event_name == 'release')
         with:
           context: .
           push: true
@@ -74,6 +74,7 @@ jobs:
             SLURM_TAG=${{ matrix.slurm-tag }}
 
       - name: Delete old images
+        if: github.event_name == 'release'
         uses: actions/delete-package-versions@v3
         with:
           package-name: ${{ steps.image-name.outputs.name }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -73,14 +73,6 @@ jobs:
           build-args: |
             SLURM_TAG=${{ matrix.slurm-tag }}
 
-      - name: Delete old images
-        if: github.event_name == 'release'
-        uses: actions/delete-package-versions@v3
-        with:
-          package-name: ${{ steps.image-name.outputs.name }}
-          min-versions-to-keep: 5
-          ignore-versions: '^(v).*'
-
   # This is a dummy job used to facilitate branch protections
   build-successful:
     needs: [ build ]

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -38,9 +38,6 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository_owner }}/${{ steps.image-name.outputs.name }}
 
-      - name: Check tags
-        run: echo "${{ steps.meta.outputs.tags }}"
-
       # Build the image but do not publish it
       - name: Build image
         uses: docker/build-push-action@v3

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,8 +6,6 @@ on:
     types: [ published ]
   push:
     branches: [ "latest" ]
-  schedule:
-    - cron: '0 0 * * 0'  # every week on sunday
 
 jobs:
   build:
@@ -39,6 +37,9 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: ghcr.io/${{ github.repository_owner }}/${{ steps.image-name.outputs.name }}
+
+      - name: Check tags
+        run: echo ${{ steps.meta.outputs.tags }}
 
       # Build the image but do not publish it
       - name: Build image
@@ -81,8 +82,6 @@ jobs:
           ignore-versions: '^(v).*'
 
   # This is a dummy job used to facilitate branch protections
-  # and trigger auto-merging when all jobs in the build matrix
-  # exit successfully.
   build-successful:
     needs: [ build ]
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -52,8 +52,8 @@ jobs:
       # Make sure sacctmgr executes
       - name: Test slurm install
         run: |
-          img=ghcr.io/${{ github.repository_owner }}/${{ steps.image-name.outputs.name }}
-          docker run --rm $img sacctmgr --version
+          tag_arr=(${{ steps.meta.outputs.tags }})
+          docker run --rm ${tag_arr[0]} sacctmgr --version
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -39,7 +39,7 @@ jobs:
           images: ghcr.io/${{ github.repository_owner }}/${{ steps.image-name.outputs.name }}
 
       - name: Check tags
-        run: echo ${{ steps.meta.outputs.tags }}
+        run: echo "${{ steps.meta.outputs.tags }}"
 
       # Build the image but do not publish it
       - name: Build image

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -54,7 +54,9 @@ jobs:
 
       # Make sure sacctmgr executes
       - name: Test slurm install
-        run: docker run --rm ${{ steps.image-name.outputs.name }} sacctmgr --version
+        run: |
+          img=ghcr.io/${{ github.repository_owner }}/${{ steps.image-name.outputs.name }}
+          docker run --rm $img sacctmgr --version
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -54,7 +54,7 @@ jobs:
 
       # Make sure sacctmgr executes
       - name: Test slurm install
-        run: docker run --rm ${{ steps.meta.outputs.tags }} sacctmgr --version
+        run: docker run --rm ${{ steps.image-name.outputs.name }} sacctmgr --version
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ jobs:
         run: /usr/local/bin/entrypoint.sh
 ```
 
-If you want to run a job several times using different containers 
+If you want to run a job several times using different containers
 (e.g., to test software against multiple Slurm versions)
 use the `strategy` directive:
 
@@ -45,8 +45,14 @@ jobs:
         run: /usr/local/bin/entrypoint.sh
 ```
 
-See the [packages](https://github.com/orgs/pitt-crc/packages?repo_name=Slurm-Test-Environment) section
-of this repository for a full list of available container names.
+See the [packages](https://github.com/orgs/pitt-crc/packages?repo_name=Slurm-Test-Environment) section of this repository for a full list of available container names.
+
+### Image Tags
+
+Specific image versions can be used by specifying the desired docker tag.
+Using the sha256 hash as a tag may work but is not recommended as the specified version may be
+deleted by automated housekeeping. Instead, use the `latest` tag for the most recent build, or a tag
+corresponding to a package release (e.g., `v0.1.0`).
 
 ## Building an Image Locally
 
@@ -62,11 +68,12 @@ To see a list of valid Slurm tags, see the [Slurm GitHub release tags](https://g
 
 ## Testing Fixtures
 
-The test environment comes partially configured with running services and mock data. 
+The test environment comes partially configured with running services and mock data.
 
 ### Running services
 
 The following services are automatically launched when spinning up a new container:
+
 - `munge`
 - `slurmdbd`
 - `slurmctld`
@@ -82,11 +89,11 @@ Slurm is configured with a single mock cluster called ``development``. The follo
 
 ## Creating a New Image
 
-Updating the `latest` branch of this repository will automatically build and 
-deploy new image version.
+Updating the `latest` branch of this repository will automatically build and deploy new image version.
 To add a new build with different package versions, make the following changes:
 
-1. Check the Slurm version you want to build against are available from the [upstream source](https://slurm.schedmd.com/overview.html).
-2. Add the necessary Slurm rms and config files to the `slurm_config` directory. 
+1. Check the Slurm version you want to build against are available from
+   the [upstream source](https://slurm.schedmd.com/overview.html).
+2. Add the necessary Slurm rms and config files to the `slurm_config` directory.
    The name of the subdirectory should match the corresponding `SLURM_TAG` build argument.
 3. Update the build matrix section of the GitHub actions workflow to include the new version.

--- a/README.md
+++ b/README.md
@@ -50,9 +50,8 @@ See the [packages](https://github.com/orgs/pitt-crc/packages?repo_name=Slurm-Tes
 ### Image Tags
 
 Specific image versions can be used by specifying the desired docker tag.
-Using the sha256 hash as a tag may work but is not recommended as the specified version may be
-deleted by automated housekeeping. Instead, use the `latest` tag for the most recent build, or a tag
-corresponding to a package release (e.g., `v0.1.0`).
+Using the sha256 hash as a tag is not recommended. 
+Instead, use the `latest` tag for the most recent build, or a tag corresponding to a package release (e.g., `v0.1.0`).
 
 ## Building an Image Locally
 


### PR DESCRIPTION
The original error mentioned in Issue #34 was resolved by some earlier work. However, the problem persisted because one of the steps was written to expect a single tag name but was receiving a list of tags. This worked fine for pushes/PRs because on;y the tag `latest` as generated. For a release, a tag for the release name was also used.

I've updated the CI to always publish the latest tag plus a release tag where appropriate.
I've also updated the workflow to only publish a package on a new release.