### PR TITLE
Removes image-name step from ci

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -24,19 +24,12 @@ jobs:
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@v2
 
-      # Define the image name for use by other steps
-      - name: Define image name
-        id: image-name
-        run: |
-          NAME=test-env-${{ matrix.slurm-tag }}
-          echo ::set-output name=name::$NAME
-
       # Extract metadata (tags and labels) for Docker
       - name: Extract Docker metadata
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ghcr.io/${{ github.repository_owner }}/${{ steps.image-name.outputs.name }}
+          images: ghcr.io/${{ github.repository_owner }}/test-env-${{ matrix.slurm-tag }}
 
       # Build the image but do not publish it
       - name: Build image
@@ -49,7 +42,7 @@ jobs:
           build-args: |
             SLURM_TAG=${{ matrix.slurm-tag }}
 
-      # Check slurm utilities execute
+      # Check slurm utilities all execute without error
       - name: Test slurm install
         run: |
           tag_arr=(${{ steps.meta.outputs.tags }})


### PR DESCRIPTION
The `image-name` step in `docker-publish.yml` was necessary when the workflow was more complex. As things have become more simplified, the step became unnecessary.