### PR TITLE
Add multiple python versions and coverage utility to images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,9 +26,9 @@ RUN yum install -y epel-release  \
   && rm -rf /var/cache/yum
 
 # Install coverage utilities, latest version last
-RUN pip-3.6 install coverage && pip-3.6 cache purge && \
-    pip-3.8 install coverage && pip-3.8 cache purge && \
-    pip-3.9 install coverage && pip-3.9 cache purge
+RUN pip-3.6 install coverage && \
+    pip-3.8 install coverage && \
+    pip-3.9 install coverage
 
 # Install mariadb
 RUN /usr/bin/mysql_install_db \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ LABEL edu.pitt.crc.slurm-tag=$SLURM_TAG
 # Install any required system tools
 RUN yum install -y epel-release  \
   && yum -y --enablerepo=powertools install \
-      python39 \
+      # Support multiple Python versions for downstream testing scenarios
+      python36 python38 python39 \
       # Required for slurm \
       munge \
       munge-devel \
@@ -24,8 +25,10 @@ RUN yum install -y epel-release  \
   && yum clean all \
   && rm -rf /var/cache/yum
 
-# Make python tools accessable without the trailing 3
-RUN ln /usr/bin/python3 /usr/bin/python && ln /usr/bin/pip3 /usr/bin/pip
+# Install coverage utilities, latest version last
+RUN pip-3.6 install coverage && pip-3.6 cache purge && \
+    pip-3.8 install coverage && pip-3.8 cache purge && \
+    pip-3.9 install coverage && pip-3.9 cache purge
 
 # Install mariadb
 RUN /usr/bin/mysql_install_db \

--- a/README.md
+++ b/README.md
@@ -100,9 +100,9 @@ Utilities are installed at following paths:
 
 | Executable Name    | Installed Path              |
 |--------------------|-----------------------------|
-| python[VERSION]    | /usr/bin/python[VERSION]    |
-| pip[VERSION]       | /usr/bin/pip[VERSION]       |
-| coverage-[VERSION] | /usr/bin/coverage-[VERSION] |
+| python<VERSION>    | /usr/bin/python<VERSION>    |
+| pip<VERSION>       | /usr/bin/pip<VERSION>       |
+| coverage-<VERSION> | /usr/bin/coverage-<VERSION> |
 
 ### Running services
 

--- a/README.md
+++ b/README.md
@@ -26,13 +26,18 @@ For a list of valid Slurm tags, see
 the [Slurm config directory](https://github.com/pitt-crc/Slurm-Test-Environment/tree/latest/slurm_config) in this
 repository.
 
+You will need to enable [Docker Buildkit](https://docs.docker.com/develop/develop-images/build_enhancements/) to build the image. 
+To do so, set the following environmental variable:
+
+```bash
+DOCKER_BUILDKIT=1
+```
+
 ### Pulling Existing Images
 
-Test environment images are stored on the GitHub container registry and can be referenced locally via the `docker`
-utility.
-For instructions on pulling images from GitHub, see
-the [official docs](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry)
-.
+Test environment images are stored on the GitHub container registry and can be referenced locally via the `docker` utility.
+For instructions on pulling images from GitHub, see the 
+[official docs](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry).
 
 Specific image versions can be used by specifying the desired docker tag.
 Using the sha256 hash as a tag is not recommended.
@@ -89,15 +94,15 @@ of the `pip` and `coverage` utilities. Installed Python versions include:
 
 - 3.6
 - 3.8
-- 3.9 (default)
+- 3.9
 
 Utilities are installed at following paths:
 
-| Executable Name   | Installed Path             |
-|-------------------|----------------------------|
-| python[VERSION]   | /usr/bin/python[VERSION]   |
-| pip-[VERSION]     | /usr/bin/pip-[VERSION]     |
-| coverage[VERSION] | /usr/bin/coverage[VERSION] |
+| Executable Name    | Installed Path              |
+|--------------------|-----------------------------|
+| python[VERSION]    | /usr/bin/python[VERSION]    |
+| pip[VERSION]       | /usr/bin/pip[VERSION]       |
+| coverage-[VERSION] | /usr/bin/coverage-[VERSION] |
 
 ### Running services
 

--- a/README.md
+++ b/README.md
@@ -98,11 +98,11 @@ of the `pip` and `coverage` utilities. Installed Python versions include:
 
 Utilities are installed at following paths:
 
-| Executable Name    | Installed Path              |
-|--------------------|-----------------------------|
-| python<VERSION>    | /usr/bin/python<VERSION>    |
-| pip<VERSION>       | /usr/bin/pip<VERSION>       |
-| coverage-<VERSION> | /usr/bin/coverage-<VERSION> |
+| Executable Name      | Installed Path                |
+|----------------------|-------------------------------|
+| `python[VERSION]`    | `/usr/bin/python[VERSION]`    |
+| `pip[VERSION]`       | `/usr/bin/pip[VERSION]`       |
+| `coverage-[VERSION]` | `/usr/bin/coverage-[VERSION]` |
 
 ### Running services
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The slurm version needs to be specified when building an image.
 The following example builds an image using Slurm version 20.02.5.1:
 
 ```bash
-docker build --build-arg SLURM_TAG=slurm-20-02-5-1
+docker build --build-arg SLURM_TAG=slurm-20-02-5-1 .
 ```
 
 For a list of valid Slurm tags, see

--- a/README.md
+++ b/README.md
@@ -80,7 +80,24 @@ jobs:
 
 ## Testing Fixtures
 
-The test environment comes partially configured with running services and mock data.
+The test environment comes partially configured with various tools, running services, and mock data.
+
+### Python versions
+
+Multiple Python versions are provided in the test environment, each having dedicated installations 
+of the `pip` and `coverage` utilities. Installed Python versions include:
+
+- 3.6
+- 3.8
+- 3.9 (default)
+
+Utilities are installed at following paths:
+
+| Executable Name   | Installed Path             |
+|-------------------|----------------------------|
+| python[VERSION]   | /usr/bin/python[VERSION]   |
+| pip-[VERSION]     | /usr/bin/pip-[VERSION]     |
+| coverage[VERSION] | /usr/bin/coverage[VERSION] |
 
 ### Running services
 


### PR DESCRIPTION
Tests often need to be run against multiple python versions. To address that need, this PR adds multiple python versions (instead of just `3.9`) in addition to the `coverage` utility to better support downstream workflows. A dedicated `coverage` install is available for each python/pip install. The default `python`, `pip`, and `coverage` default to the latest python version.