### PR TITLE
Makes entrypoint rerunnable

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -42,6 +42,12 @@ jobs:
           build-args: |
             SLURM_TAG=${{ matrix.slurm-tag }}
 
+      - name: Test container is restartable
+        run: |
+          docker run --name rerun_test_container ${tag_arr[0]}
+          docker container start -i rerun_test_container
+          docker container rm rerun_test_container
+
       # Check slurm utilities all execute without error
       - name: Test slurm install
         run: |

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -44,7 +44,8 @@ jobs:
 
       - name: Test container is restartable
         run: |
-          docker run --name rerun_test_container ${tag_arr[0]}
+          docker container create --name rerun_test_container ${tag_arr[0]}
+          docker container start -i rerun_test_container
           docker container start -i rerun_test_container
           docker container rm rerun_test_container
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,14 +6,14 @@ echo "Launching sql server..."
 sleep 3 # Wait for mysql to start up
 
 echo "Creating Slurm account database..."
-mysql -NBe "CREATE DATABASE slurm_acct_db"
-mysql -NBe "CREATE USER 'slurm'@'localhost'"
+mysql -NBe "CREATE DATABASE IF NOT EXISTS slurm_acct_db"
+mysql -NBe "CREATE USER IF NOT EXISTS 'slurm'@'localhost'"
 mysql -NBe "GRANT USAGE ON *.* to 'slurm'@'localhost'"
 mysql -NBe "GRANT ALL PRIVILEGES on slurm_acct_db.* to 'slurm'@'localhost'"
 mysql -NBe "FLUSH PRIVILEGES"
 
 echo "Create munge key..."
-/usr/sbin/create-munge-key
+/usr/sbin/create-munge-key -f
 
 echo "Starting munge..."
 /usr/sbin/runuser -u munge -- /usr/sbin/munged
@@ -23,7 +23,7 @@ echo "Starting slurmdbd..."
 sleep 3 # Wait for slurmdbd to start up
 
 echo "Starting slurmctld..."
-mkdir /var/slurmstate
+mkdir -p /var/slurmstate
 chown slurm /var/slurmstate
 /usr/sbin/slurmctld -c
 sleep 3 # Wait for slurmctld to start up


### PR DESCRIPTION
Launching an existing container fails because the entrypoint tries to create databases/directories that already exist. I've added a few conditionals and enabled a few options to prevent this from happening.