### PR TITLE
Add make utility to container environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,9 @@ RUN yum install -y epel-release  \
       rrdtool-devel \
       perl-Switch \
       hwloc-libs \
-      # Added for integration with IDEs \
+      # General tools provided explicitly for use by downstream services
       which \
+      make \
   && yum clean all \
   && rm -rf /var/cache/yum
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,13 @@ jobs:
 
 The test environment comes partially configured with various tools, running services, and mock data.
 
+### General Utilities
+
+The following commandline tools are explicitly provided in the testing environment.
+
+- ``which`` (Required for compatibility with some IDE docker integrations)
+- ``make``
+
 ### Python versions
 
 Multiple Python versions are provided in the test environment, each having dedicated installations 


### PR DESCRIPTION
Make is generically used among most of our downstream projects. I'm adding it here so it doesn't need to be added to every downstream project.