### PR TITLE
Clears pip cache after installing Python tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN yum install -y epel-release  \
   && yum install -y --enablerepo=powertools \
       # Support multiple Python versions for downstream testing scenarios
       python38 python39 \
-      # Required for slurm \
+      # Required for slurm
       munge \
       munge-devel \
       mariadb-server \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ LABEL edu.pitt.crc.slurm-tag=$SLURM_TAG
 
 # Install any required system tools
 RUN yum install -y epel-release  \
-  && yum -y --enablerepo=powertools install \
+  && yum install -y --enablerepo=powertools \
       # Support multiple Python versions for downstream testing scenarios
       python38 python39 \
       # Required for slurm \
@@ -27,8 +27,8 @@ RUN yum install -y epel-release  \
   && rm -rf /var/cache/yum
 
 # Install coverage utilities, latest version last
-RUN pip-3.8 install -U coverage==6.4 setuptools==64 pip==21.3 && \
-    pip-3.9 install -U coverage==6.4 setuptools==64 pip==21.3
+RUN pip-3.8 install coverage==6.4 setuptools==64 pip==21.3 && pip-3.8 cache purge  && \
+    pip-3.9 install coverage==6.4 setuptools==64 pip==21.3 && pip-3.9 cache purge
 
 # Install mariadb
 RUN /usr/bin/mysql_install_db \


### PR DESCRIPTION
This PR is more of a "best practices" edit. In practice, the PIP cache takes up very little space. 