### PR TITLE
Seperates build and publish workflows

### DIFF
--- a/.github/workflows/DockerPublish.yml
+++ b/.github/workflows/DockerPublish.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    name: Build Documentation
+    name: Build Images
     uses: ./.github/workflows/DockerTest.yml
 
   publish:

--- a/.github/workflows/DockerPublish.yml
+++ b/.github/workflows/DockerPublish.yml
@@ -23,14 +23,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Download images from GitHub artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: ${{ matrix.slurm-tag }}
-
-      - name: Load image
-        run: docker load --input ${{ matrix.slurm-tag }}.tar
-
       - name: Extract Docker metadata
         id: meta
         uses: docker/metadata-action@v4

--- a/.github/workflows/DockerPublish.yml
+++ b/.github/workflows/DockerPublish.yml
@@ -1,7 +1,6 @@
 name: Publish Docker Images
 
 on:
-  push:
   release:
     types: [ "released" ]
 
@@ -24,12 +23,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Extract Docker metadata
-        id: meta
-        uses: docker/metadata-action@v4
-        with:
-          images: ghcr.io/${{ github.repository_owner }}/test-env-${{ matrix.slurm-tag }}
-
       - name: Download images from GitHub artifacts
         uses: actions/download-artifact@v3
         with:
@@ -37,6 +30,12 @@ jobs:
 
       - name: Load image
         run: docker load --input ${{ matrix.slurm-tag }}.tar
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/test-env-${{ matrix.slurm-tag }}
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2

--- a/.github/workflows/DockerPublish.yml
+++ b/.github/workflows/DockerPublish.yml
@@ -13,6 +13,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     name: Publish Docker Images
+    needs: [ build ]
 
     strategy:
       fail-fast: false

--- a/.github/workflows/DockerPublish.yml
+++ b/.github/workflows/DockerPublish.yml
@@ -24,15 +24,19 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/test-env-${{ matrix.slurm-tag }}
+
       - name: Download images from GitHub artifacts
         uses: actions/download-artifact@v3
         with:
           name: ${{ matrix.slurm-tag }}
 
       - name: Load image
-        run: |
-          docker load --input ${{ matrix.slurm-tag }}.tar
-          docker image ls -a
+        run: docker load --input ${{ matrix.slurm-tag }}.tar
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2

--- a/.github/workflows/DockerPublish.yml
+++ b/.github/workflows/DockerPublish.yml
@@ -1,0 +1,48 @@
+name: Publish Docker Images
+
+on:
+  release:
+    types: [ "released" ]
+
+jobs:
+  build:
+    name: Build Documentation
+    uses: ./.github/workflows/DockerTest.yml
+
+  publish:
+    runs-on: ubuntu-latest
+    name: Publish Docker Images
+
+    strategy:
+      fail-fast: false
+      matrix:
+        slurm-tag: [ "slurm-20-02-5-1", "slurm-20-11-9-1", "slurm-22-05-2-1" ]
+
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Download images from GitHub artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ matrix.slurm-tag }}
+
+      - name: Load image
+        run: docker load --input ${{ matrix.slurm-tag }}.tar
+
+      - name: Login to GitHub Container Registry
+        if: github.event_name == 'release'
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish built image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: SLURM_TAG=${{ matrix.slurm-tag }}

--- a/.github/workflows/DockerPublish.yml
+++ b/.github/workflows/DockerPublish.yml
@@ -1,6 +1,7 @@
 name: Publish Docker Images
 
 on:
+  push:
   release:
     types: [ "released" ]
 
@@ -28,21 +29,6 @@ jobs:
           name: ${{ matrix.slurm-tag }}
 
       - name: Load image
-        run: docker load --input ${{ matrix.slurm-tag }}.tar
-
-      - name: Login to GitHub Container Registry
-        if: github.event_name == 'release'
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Publish built image
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: SLURM_TAG=${{ matrix.slurm-tag }}
+        run: |
+          docker load --input ${{ matrix.slurm-tag }}.tar
+          docker image ls -a

--- a/.github/workflows/DockerPublish.yml
+++ b/.github/workflows/DockerPublish.yml
@@ -35,7 +35,6 @@ jobs:
           docker image ls -a
 
       - name: Login to GitHub Container Registry
-        if: github.event_name == 'release'
         uses: docker/login-action@v2
         with:
           registry: ghcr.io

--- a/.github/workflows/DockerPublish.yml
+++ b/.github/workflows/DockerPublish.yml
@@ -7,12 +7,12 @@ on:
 
 jobs:
   build:
-    name: Build
+    name: Build Images
     uses: ./.github/workflows/DockerTest.yml
 
   publish:
     runs-on: ubuntu-latest
-    name: Publish Docker Images
+    name: Publish Images
     needs: [ build ]
 
     strategy:
@@ -48,7 +48,6 @@ jobs:
       - name: Publish built image
         uses: docker/build-push-action@v3
         with:
-          context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/DockerPublish.yml
+++ b/.github/workflows/DockerPublish.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    name: Build Images
+    name: Build
     uses: ./.github/workflows/DockerTest.yml
 
   publish:
@@ -33,3 +33,21 @@ jobs:
         run: |
           docker load --input ${{ matrix.slurm-tag }}.tar
           docker image ls -a
+
+      - name: Login to GitHub Container Registry
+        if: github.event_name == 'release'
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # - name: Publish built image
+      #   uses: docker/build-push-action@v3
+      #   with:
+      #     context: .
+      #     push: true
+      #     tags: ${{ steps.meta.outputs.tags }}
+      #     labels: ${{ steps.meta.outputs.labels }}
+      #     build-args: SLURM_TAG=${{ matrix.slurm-tag }}
+#

--- a/.github/workflows/DockerPublish.yml
+++ b/.github/workflows/DockerPublish.yml
@@ -1,7 +1,7 @@
 name: Publish Docker Images
 
 on:
-  push:
+  #push:
   release:
     types: [ "released" ]
 

--- a/.github/workflows/DockerPublish.yml
+++ b/.github/workflows/DockerPublish.yml
@@ -1,7 +1,7 @@
 name: Publish Docker Images
 
 on:
-  #push:
+  push:
   release:
     types: [ "released" ]
 

--- a/.github/workflows/DockerPublish.yml
+++ b/.github/workflows/DockerPublish.yml
@@ -45,12 +45,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # - name: Publish built image
-      #   uses: docker/build-push-action@v3
-      #   with:
-      #     context: .
-      #     push: true
-      #     tags: ${{ steps.meta.outputs.tags }}
-      #     labels: ${{ steps.meta.outputs.labels }}
-      #     build-args: SLURM_TAG=${{ matrix.slurm-tag }}
-#
+      - name: Publish built image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: SLURM_TAG=${{ matrix.slurm-tag }}

--- a/.github/workflows/DockerTest.yml
+++ b/.github/workflows/DockerTest.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    name: Build and Test Images
+    name: Test Images
 
     strategy:
       fail-fast: false

--- a/.github/workflows/DockerTest.yml
+++ b/.github/workflows/DockerTest.yml
@@ -1,9 +1,8 @@
 name: Docker Images
 
 on:
+  workflow_call:
   pull_request:
-  release:
-    types: [ "released" ]
   push:
     branches: [ "latest" ]
 
@@ -39,53 +38,40 @@ jobs:
           load: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            SLURM_TAG=${{ matrix.slurm-tag }}
+          build-args: SLURM_TAG=${{ matrix.slurm-tag }}
+          outputs: type=docker,dest=${{ matrix.slurm-tag }}.tar
 
       - name: Test container is restartable
         run: |
-          tag_array=(${{ steps.meta.outputs.tags }})
+          tag_array=(${{ steps.meta.outputs.tags }}) # Use the first tag from the tags array
           docker container create --name rerun_test_container ${tag_array[0]}
           docker container start -i rerun_test_container
           docker container start -i rerun_test_container
           docker container rm rerun_test_container
 
-      # Check slurm utilities all execute without error
-      - name: Test slurm install
+      - name: Test Slurm utilities are installed
         run: |
           tag_array=(${{ steps.meta.outputs.tags }})
           docker run --rm ${tag_array[0]} sacctmgr -V
           docker run --rm ${tag_array[0]} slurmctld -V
           docker run --rm ${tag_array[0]} slurmdbd -V
 
-      - name: Login to GitHub Container Registry
+      - name: Upload artifact
         if: github.event_name == 'release'
-        uses: docker/login-action@v2
+        uses: actions/upload-artifact@v3
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      # Only publish new images if the event is a release
-      - name: Publish built image
-        if: github.event_name == 'release'
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            SLURM_TAG=${{ matrix.slurm-tag }}
+          name: ${{ matrix.slurm-tag }}
+          path: ${{ matrix.slurm-tag }}.tar
+          retention-days: 5
 
   # This is a dummy job used to facilitate branch protections
   build-successful:
     if: ${{ always() }}
-    name: Builds Were Successful
+    name: Report Build Status
     runs-on: ubuntu-latest
     needs: [ build ]
     steps:
-      - name: Mark as Successful
+      - name: Report status
         shell: bash
         run: |
           if [[ success == ${{ needs.build.result }} ]]

--- a/.github/workflows/DockerTest.yml
+++ b/.github/workflows/DockerTest.yml
@@ -23,13 +23,10 @@ jobs:
       - name: Build Docker image
         uses: docker/build-push-action@v3
         with:
+          load: true
           tags: test-image
           labels: ${{ steps.meta.outputs.labels }}
           build-args: SLURM_TAG=${{ matrix.slurm-tag }}
-          outputs: type=docker,dest=${{ matrix.slurm-tag }}.tar
-
-      - name: Load image into Docker
-        run: docker load -i ${{ matrix.slurm-tag }}.tar
 
       - name: Test container is restartable
         run: |
@@ -43,14 +40,6 @@ jobs:
           docker run --rm test-image sacctmgr -V
           docker run --rm test-image slurmctld -V
           docker run --rm test-image slurmdbd -V
-
-      - name: Upload artifact
-        if: ${{ github.event_name }} == 'workflow_call'
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ matrix.slurm-tag }}
-          path: ${{ matrix.slurm-tag }}.tar
-          retention-days: 5
 
   # This is a dummy job used to facilitate branch protections
   build-successful:

--- a/.github/workflows/DockerTest.yml
+++ b/.github/workflows/DockerTest.yml
@@ -1,4 +1,4 @@
-name: Docker Images
+name: Test Docker Images
 
 on:
   workflow_call:
@@ -53,7 +53,7 @@ jobs:
           docker run --rm ${tag_array[0]} slurmdbd -V
 
       - name: Upload artifact
-        if: github.event_name == 'release'
+        if: github.event_name == 'workflow_call'
         uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.slurm-tag }}

--- a/.github/workflows/DockerTest.yml
+++ b/.github/workflows/DockerTest.yml
@@ -17,18 +17,16 @@ jobs:
         slurm-tag: [ "slurm-20-02-5-1", "slurm-20-11-9-1", "slurm-22-05-2-1" ]
 
     steps:
-      - name: Setup Docker buildx
+      - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      # Extract metadata (tags and labels) for Docker
       - name: Extract Docker metadata
         id: meta
         uses: docker/metadata-action@v4
         with:
           images: ghcr.io/${{ github.repository_owner }}/test-env-${{ matrix.slurm-tag }}
 
-      # Build the image but do not publish it
-      - name: Build image
+      - name: Build Docker image
         uses: docker/build-push-action@v3
         with:
           tags: ${{ steps.meta.outputs.tags }}
@@ -36,8 +34,8 @@ jobs:
           build-args: SLURM_TAG=${{ matrix.slurm-tag }}
           outputs: type=docker,dest=${{ matrix.slurm-tag }}.tar
 
-      - name: Load built image
-        run: docker load ${{ matrix.slurm-tag }}.tar
+      - name: Load image into Docker
+        run: docker load -i ${{ matrix.slurm-tag }}.tar
 
       - name: Test container is restartable
         run: |

--- a/.github/workflows/DockerTest.yml
+++ b/.github/workflows/DockerTest.yml
@@ -20,16 +20,10 @@ jobs:
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Extract Docker metadata
-        id: meta
-        uses: docker/metadata-action@v4
-        with:
-          images: ghcr.io/${{ github.repository_owner }}/test-env-${{ matrix.slurm-tag }}
-
       - name: Build Docker image
         uses: docker/build-push-action@v3
         with:
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: test-image
           labels: ${{ steps.meta.outputs.labels }}
           build-args: SLURM_TAG=${{ matrix.slurm-tag }}
           outputs: type=docker,dest=${{ matrix.slurm-tag }}.tar
@@ -39,18 +33,16 @@ jobs:
 
       - name: Test container is restartable
         run: |
-          tag_array=(${{ steps.meta.outputs.tags }}) # Use the first tag from the tags array
-          docker container create --name rerun_test_container ${tag_array[0]}
+          docker container create --name rerun_test_container test-image
           docker container start -i rerun_test_container
           docker container start -i rerun_test_container
           docker container rm rerun_test_container
 
       - name: Test Slurm utilities are installed
         run: |
-          tag_array=(${{ steps.meta.outputs.tags }})
-          docker run --rm ${tag_array[0]} sacctmgr -V
-          docker run --rm ${tag_array[0]} slurmctld -V
-          docker run --rm ${tag_array[0]} slurmdbd -V
+          docker run --rm test-image sacctmgr -V
+          docker run --rm test-image slurmctld -V
+          docker run --rm test-image slurmdbd -V
 
       - name: Upload artifact
         if: ${{ github.event_name }} == 'workflow_call'

--- a/.github/workflows/DockerTest.yml
+++ b/.github/workflows/DockerTest.yml
@@ -53,7 +53,7 @@ jobs:
           docker run --rm ${tag_array[0]} slurmdbd -V
 
       - name: Upload artifact
-        if: github.event_name == 'workflow_call'
+        if: ${{ github.event_name }} == 'workflow_call'
         uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.slurm-tag }}
@@ -63,7 +63,7 @@ jobs:
   # This is a dummy job used to facilitate branch protections
   build-successful:
     if: ${{ always() }}
-    name: Report Build Status
+    name: Report Status
     runs-on: ubuntu-latest
     needs: [ build ]
     steps:

--- a/.github/workflows/DockerTest.yml
+++ b/.github/workflows/DockerTest.yml
@@ -17,9 +17,6 @@ jobs:
         slurm-tag: [ "slurm-20-02-5-1", "slurm-20-11-9-1", "slurm-22-05-2-1" ]
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@v2
 
@@ -34,12 +31,13 @@ jobs:
       - name: Build image
         uses: docker/build-push-action@v3
         with:
-          context: .
-          load: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: SLURM_TAG=${{ matrix.slurm-tag }}
           outputs: type=docker,dest=${{ matrix.slurm-tag }}.tar
+
+      - name: Load built image
+        run: docker load ${{ matrix.slurm-tag }}.tar
 
       - name: Test container is restartable
         run: |

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Slurm Test Environments
 
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/86b83c73f89642dfad48f3a9ec1f0b66)](https://app.codacy.com/gh/pitt-crc/Slurm-Test-Environment/dashboard)
-[![Docker Images](https://github.com/pitt-crc/Slurm-Test-Environment/actions/workflows/Docker.yml/badge.svg)](https://github.com/pitt-crc/Slurm-Test-Environment/actions/workflows/Docker.yml)
+[![](https://github.com/pitt-crc/Slurm-Test-Environment/actions/workflows/DockerTest.yml/badge.svg)](https://github.com/pitt-crc/Slurm-Test-Environment/actions/workflows/DockerTest.yml)
+[![](https://github.com/pitt-crc/Slurm-Test-Environment/actions/workflows/DockerPublish.yml/badge.svg)](https://github.com/pitt-crc/Slurm-Test-Environment/actions/workflows/DockerPublish.yml)
 
 Dockerized environments for testing software against a variety of [Slurm](https://slurm.schedmd.com/overview.html)
 versions.

--- a/README.md
+++ b/README.md
@@ -141,9 +141,12 @@ Slurm is configured with a single mock cluster called ``development`` along with
 Creating a new release from this repository will automatically build and publish new image versions.
 To add a new Slurm version to the build process, make the following changes:
 
-1. Add the necessary Slurm rpms and config files to the `slurm_config` directory.
+1. Add the necessary Slurm RPMs and config files to the `slurm_config` directory.
    The name of the subdirectory should match the corresponding `SLURM_TAG` build argument.
-2. Update the build matrix section of the GitHub actions workflow to include the new version.
+2. Update the strategy matrix in the
+   [testing](https://github.com/pitt-crc/Slurm-Test-Environment/blob/latest/.github/workflows/DockerTest.yml) 
+   and [publication](https://github.com/pitt-crc/Slurm-Test-Environment/blob/latest/.github/workflows/DockerPublish.yml) 
+   workflows to include the new slurm tag.
 
 ### Building New Slurm RPMs
 


### PR DESCRIPTION
Separating the build and publish steps into separate jobs ensures images are only published to the container registry if all images build. In the previous workflow, it was possible for some images to successfully build/publish while others would fail. This creates confusion around the versioning of the published images.