### PR TITLE
Rename partitions to use numberic identifiers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # Uncompressed slurm RPMs
 slurm_config/**/*.rpm
+
+# IDE files
+.idea

--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ The installed Slurm instance is configured with the following Slurm partitions:
 
 | Cluster Name | Partition Name |
 |--------------|----------------|
-| development  | normal         |
-| development  | debug          |
+| development  | partition1     |
+| development  | partition2     |
 
 The cluster als includes the following Slurm accounts:
 

--- a/slurm_config/slurm-20-02-5-1/slurm.conf
+++ b/slurm_config/slurm-20-02-5-1/slurm.conf
@@ -178,5 +178,5 @@ AccountingStorageTRES=gres/gpu,license/stata,gres/scratch
 NodeName=c[1-10] RealMemory=1000
 #
 # PARTITIONS
-PartitionName=normal Default=yes Nodes=c[1-5] Priority=50 DefMemPerCPU=500 Shared=NO MaxNodes=1 MaxTime=5-00:00:00 DefaultTime=5-00:00:00 State=UP
-PartitionName=debug Nodes=c[6-10] Priority=50 DefMemPerCPU=500 Shared=NO MaxNodes=1 MaxTime=5-00:00:00 DefaultTime=5-00:00:00 State=UP
+PartitionName=partition1 Default=yes Nodes=c[1-5] Priority=50 DefMemPerCPU=500 Shared=NO MaxNodes=1 MaxTime=5-00:00:00 DefaultTime=5-00:00:00 State=UP
+PartitionName=partition2 Nodes=c[6-10] Priority=50 DefMemPerCPU=500 Shared=NO MaxNodes=1 MaxTime=5-00:00:00 DefaultTime=5-00:00:00 State=UP

--- a/slurm_config/slurm-20-11-9-1/slurm.conf
+++ b/slurm_config/slurm-20-11-9-1/slurm.conf
@@ -178,5 +178,5 @@ AccountingStorageTRES=gres/gpu,license/stata,gres/scratch
 NodeName=c RealMemory=1000
 #
 # PARTITIONS
-PartitionName=normal Default=yes Nodes=c[1-5] Priority=50 DefMemPerCPU=500 Shared=NO MaxNodes=1 MaxTime=5-00:00:00 DefaultTime=5-00:00:00 State=UP
-PartitionName=debug Nodes=c[6-10] Priority=50 DefMemPerCPU=500 Shared=NO MaxNodes=1 MaxTime=5-00:00:00 DefaultTime=5-00:00:00 State=UP
+PartitionName=partition1 Default=yes Nodes=c[1-5] Priority=50 DefMemPerCPU=500 Shared=NO MaxNodes=1 MaxTime=5-00:00:00 DefaultTime=5-00:00:00 State=UP
+PartitionName=partition2 Nodes=c[6-10] Priority=50 DefMemPerCPU=500 Shared=NO MaxNodes=1 MaxTime=5-00:00:00 DefaultTime=5-00:00:00 State=UP

--- a/slurm_config/slurm-22-05-2-1/slurm.conf
+++ b/slurm_config/slurm-22-05-2-1/slurm.conf
@@ -178,5 +178,5 @@ AccountingStorageTRES=gres/gpu,license/stata,gres/scratch
 NodeName=c[1-10] RealMemory=1000
 #
 # PARTITIONS
-PartitionName=normal Default=yes Nodes=c[1-5] Priority=50 DefMemPerCPU=500 Shared=NO MaxNodes=1 MaxTime=5-00:00:00 DefaultTime=5-00:00:00 State=UP
-PartitionName=debug Nodes=c[6-10] Priority=50 DefMemPerCPU=500 Shared=NO MaxNodes=1 MaxTime=5-00:00:00 DefaultTime=5-00:00:00 State=UP
+PartitionName=partition1 Default=yes Nodes=c[1-5] Priority=50 DefMemPerCPU=500 Shared=NO MaxNodes=1 MaxTime=5-00:00:00 DefaultTime=5-00:00:00 State=UP
+PartitionName=partition2 Nodes=c[6-10] Priority=50 DefMemPerCPU=500 Shared=NO MaxNodes=1 MaxTime=5-00:00:00 DefaultTime=5-00:00:00 State=UP


### PR DESCRIPTION
Renames the `normal` and `debug` partitions to `partition1` and `partition2`.