### PR TITLE
Add grep to general tool installations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN yum install -y epel-release  \
       # General tools provided explicitly for use by downstream services
       which \
       make \
+      grep \
   && yum clean all \
   && rm -rf /var/cache/yum
 


### PR DESCRIPTION
I'd like to be able to use grep in the test environment, specifically for incorporating

```
until scontrol ping | grep UP
do
  sleep 1
done
```

into the entrypoint script for checking that the SLURM controller daemon is running.
