### PR TITLE
Attempt to fix pycharm entrypoint issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,4 +55,4 @@ COPY --chown=slurm --chmod=600 slurm_config/$SLURM_VERSION/slurmdbd.conf /etc/sl
 # The entrypoint script starts the DB and defines necessary DB constructs
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 
-ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD ["/usr/local/bin/entrypoint.sh"]


### PR DESCRIPTION
Pycharm is giving me issues when I use the IDE's debugger, it no longer runs the entrypoint properly regardless of how I override it. Looking to see if supplying this as as command instead works better with how the tests are started