### PR TITLE
Drop coverage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,9 +29,9 @@ RUN yum install -y epel-release  \
   && yum clean all \
   && rm -rf /var/cache/yum
 
-# Install coverage utilities, latest version last
-RUN pip-3.8 install coverage==6.4 setuptools==64 pip==21.3 && pip-3.8 cache purge  && \
-    pip-3.9 install coverage==6.4 setuptools==64 pip==21.3 && pip-3.9 cache purge
+# Install more recent pip versions
+RUN pip-3.8 install pip==21.3 && pip-3.8 cache purge  && \
+    pip-3.9 install pip==21.3 && pip-3.9 cache purge
 
 # Install mariadb
 RUN /usr/bin/mysql_install_db \

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Installed Python versions include:
 - 3.8
 - 3.9
 
-All Python interpreters are installed in the standard location under `/usr/bin/`.
+All Python interpreters and utilities are installed in the standard location under `/usr/bin/`.
 
 ### General Utilities
 

--- a/README.md
+++ b/README.md
@@ -121,27 +121,13 @@ The following services are automatically launched when spinning up a new contain
 
 ### Python versions
 
-Multiple Python versions are provided in the test environment, each having dedicated installations
-of the `pip` and `coverage` utilities. Installed Python versions include:
+Multiple Python versions are provided in the test environment, each having dedicated a dedicated `pip` installation.
+Installed Python versions include:
 
 - 3.8
 - 3.9
 
-Utilities are installed at following paths:
-
-| Executable Name             | Installed Path                       |
-| --------------------------- | ------------------------------------ |
-| `python[PYTHON-VERSION]`    | `/usr/bin/python[PYTHON-VERSION]`    |
-| `pip[PYTHON-VERSION]`       | `/usr/bin/pip[PYTHON-VERSION]`       |
-| `coverage-[PYTHON-VERSION]` | `/usr/bin/coverage-[PYTHON-VERSION]` |
-
-For each Python install, the following utilities versions are guaranteed:
-
-| Package Name | Package Version |
-| ------------ | --------------- |
-| `coverage`   | `6.4`           |
-| `setuptools` | `64`            |
-| `pip`        | `21.3`          |
+All Python interpreters are installed in the standard location under `/usr/bin/`.
 
 ### General Utilities
 


### PR DESCRIPTION
This PR removes dedicated installs for `coverage` and `setuptools`. Most projects (all, as far as I can tell) install their own version of these utilities as part of heir testing/publication workflows. 