### PR TITLE
fix: issue 99, nodes now show up in sinfo/scontrol commands

### DIFF
--- a/slurm_config/20.02.5.1/slurm.conf
+++ b/slurm_config/20.02.5.1/slurm.conf
@@ -175,7 +175,7 @@ GresTypes=gpu,mic,nvme
 AccountingStorageTRES=gres/gpu,license/stata,gres/scratch
 
 # COMPUTE NODES
-NodeName=c[1-10] RealMemory=1000
+NodeName=c[1-10] RealMemory=1000 NodeAddr=127.0.0.[2-11]
 #
 # PARTITIONS
 PartitionName=partition1 Default=yes Nodes=c[1-5] Priority=50 DefMemPerCPU=500 Shared=NO MaxNodes=1 MaxTime=5-00:00:00 DefaultTime=5-00:00:00 State=UP

--- a/slurm_config/20.11.9.1/slurm.conf
+++ b/slurm_config/20.11.9.1/slurm.conf
@@ -175,7 +175,7 @@ GresTypes=gpu,mic,nvme
 AccountingStorageTRES=gres/gpu,license/stata,gres/scratch
 
 # COMPUTE NODES
-NodeName=c[1-10] RealMemory=1000
+NodeName=c[1-10] RealMemory=1000 NodeAddr=127.0.0.[2-11]
 #
 # PARTITIONS
 PartitionName=partition1 Default=yes Nodes=c[1-5] Priority=50 DefMemPerCPU=500 Shared=NO MaxNodes=1 MaxTime=5-00:00:00 DefaultTime=5-00:00:00 State=UP

--- a/slurm_config/22.05.2.1/slurm.conf
+++ b/slurm_config/22.05.2.1/slurm.conf
@@ -175,7 +175,7 @@ GresTypes=gpu,mic,nvme
 AccountingStorageTRES=gres/gpu,license/stata,gres/scratch
 
 # COMPUTE NODES
-NodeName=c[1-10] RealMemory=1000
+NodeName=c[1-10] RealMemory=1000 NodeAddr=127.0.0.[2-11]
 #
 # PARTITIONS
 PartitionName=partition1 Default=yes Nodes=c[1-5] Priority=50 DefMemPerCPU=500 Shared=NO MaxNodes=1 MaxTime=5-00:00:00 DefaultTime=5-00:00:00 State=UP

--- a/slurm_config/23.02.5.1/slurm.conf
+++ b/slurm_config/23.02.5.1/slurm.conf
@@ -175,7 +175,7 @@ GresTypes=gpu,mic,nvme
 AccountingStorageTRES=gres/gpu,license/stata,gres/scratch
 
 # COMPUTE NODES
-NodeName=c[1-10] RealMemory=1000
+NodeName=c[1-10] RealMemory=1000 NodeAddr=127.0.0.[2-11]
 #
 # PARTITIONS
 PartitionName=partition1 Default=yes Nodes=c[1-5] Priority=50 DefMemPerCPU=500 Shared=NO MaxNodes=1 MaxTime=5-00:00:00 DefaultTime=5-00:00:00 State=UP


### PR DESCRIPTION
This will close #99. In order for nodes to show up via `sinfo` or `scontrol`, Slurm needs to be able to resolve the `NodeName`. By adding a _not real_ IP address for `NodeAddr`, the nodes now show up in a state of `UNKNOWN`.

```
[root@1cd447daf4ac /]# sinfo
PARTITION   AVAIL  TIMELIMIT  NODES  STATE NODELIST
partition1*    up 5-00:00:00      5   unk* c[1-5]
partition2     up 5-00:00:00      5   unk* c[6-10]

[root@1cd447daf4ac /]# scontrol show node c6
NodeName=c6 CoresPerSocket=1
   CPUAlloc=0 CPUEfctv=1 CPUTot=1 CPULoad=N/A
   AvailableFeatures=(null)
   ActiveFeatures=(null)
   Gres=(null)
   NodeAddr=127.0.0.7 NodeHostName=c6
   RealMemory=1000 AllocMem=0 FreeMem=N/A Sockets=1 Boards=1
   State=UNKNOWN+NOT_RESPONDING ThreadsPerCore=1 TmpDisk=0 Weight=1 Owner=N/A MCS_label=N/A
   Partitions=partition2
   BootTime=None SlurmdStartTime=None
   LastBusyTime=Unknown
   CfgTRES=cpu=1,mem=1000M,billing=1
   AllocTRES=
   CapWatts=n/a
   CurrentWatts=0 AveWatts=0
   ExtSensorsJoules=n/s ExtSensorsWatts=0 ExtSensorsTemp=n/s
```

ref: https://slurm.schedmd.com/slurm.conf.html#OPT_NodeName